### PR TITLE
[WIP] Add Stream/Sink impls to shared references of FutSender, FutReceiver

### DIFF
--- a/src/mpmc.rs
+++ b/src/mpmc.rs
@@ -528,18 +528,33 @@ impl<T> Clone for MPMCFutSender<T> {
     }
 }
 
+impl<T> Sink for &MPMCFutSender<T> {
+    type SinkItem = T;
+    type SinkError = SendError<T>;
+
+    #[inline(always)]
+    fn start_send(&mut self, msg: T) -> StartSend<T, SendError<T>> {
+        (&self.sender).start_send(msg)
+    }
+
+    #[inline(always)]
+    fn poll_complete(&mut self) -> Poll<(), SendError<T>> {
+        Ok(Async::Ready(()))
+    }
+}
+
 impl<T> Sink for MPMCFutSender<T> {
     type SinkItem = T;
     type SinkError = SendError<T>;
 
     #[inline(always)]
     fn start_send(&mut self, msg: T) -> StartSend<T, SendError<T>> {
-        self.sender.start_send(msg)
+        (&*self).start_send(msg)
     }
 
     #[inline(always)]
     fn poll_complete(&mut self) -> Poll<(), SendError<T>> {
-        Ok(Async::Ready(()))
+        (&*self).poll_complete()
     }
 }
 
@@ -551,13 +566,23 @@ impl<T> Clone for MPMCFutReceiver<T> {
     }
 }
 
+impl<T> Stream for &MPMCFutReceiver<T> {
+    type Item = T;
+    type Error = ();
+
+    #[inline(always)]
+    fn poll(&mut self) -> Poll<Option<T>, ()> {
+        (&self.receiver).poll()
+    }
+}
+
 impl<T> Stream for MPMCFutReceiver<T> {
     type Item = T;
     type Error = ();
 
     #[inline(always)]
     fn poll(&mut self) -> Poll<Option<T>, ()> {
-        self.receiver.poll()
+        (&*self).poll()
     }
 }
 


### PR DESCRIPTION
Resolves #4 .

UniReceiver hasn't been done yet, as it is a bit more complicated than
the others.