### PR TITLE
[WIP] upgrade futures to 0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,8 @@ edition = "2018"
 
 [dependencies]
 crossbeam = "0.7.1"
-futures = "0.1.27"
+futures-core = "0.3.0"
+futures-sink = "0.3.0"
 smallvec = "0.6.9"
 parking_lot = "0.8.0"
 time = "0.1.42"
@@ -21,3 +22,6 @@ atomic_utilities = "0.5.0"
 
 # tokio = "0.1.20"
 # tokio-timer = "0.2.11"
+
+[dev-dependencies]
+futures = "0.3.1"

--- a/src/mpmc.rs
+++ b/src/mpmc.rs
@@ -5,10 +5,14 @@ use crate::multiqueue::{
 };
 use crate::wait::Wait;
 
+use std::pin::Pin;
 use std::sync::mpsc::{RecvError, SendError, TryRecvError, TrySendError};
 
-extern crate futures;
-use self::futures::{Async, Poll, Sink, StartSend, Stream};
+extern crate futures_core;
+extern crate futures_sink;
+use self::futures_core::stream::Stream;
+use self::futures_core::task::{Context, Poll};
+use self::futures_sink::Sink;
 
 /// This class is the sending half of the mpmc ```MultiQueue```. It supports both
 /// single and multi consumer modes with competitive performance in each case.
@@ -528,33 +532,51 @@ impl<T> Clone for MPMCFutSender<T> {
     }
 }
 
-impl<T> Sink for &MPMCFutSender<T> {
-    type SinkItem = T;
-    type SinkError = SendError<T>;
+impl<T> Sink<T> for &MPMCFutSender<T> {
+    type Error = SendError<T>;
 
     #[inline(always)]
-    fn start_send(&mut self, msg: T) -> StartSend<T, SendError<T>> {
-        (&self.sender).start_send(msg)
+    fn poll_ready(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), SendError<T>>> {
+        Pin::new(&mut &self.sender).poll_ready(cx)
     }
 
     #[inline(always)]
-    fn poll_complete(&mut self) -> Poll<(), SendError<T>> {
-        Ok(Async::Ready(()))
+    fn start_send(self: Pin<&mut Self>, msg: T) -> Result<(), SendError<T>> {
+        Pin::new(&mut &self.sender).start_send(msg)
+    }
+
+    #[inline(always)]
+    fn poll_flush(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Result<(), SendError<T>>> {
+        Poll::Ready(Ok(()))
+    }
+
+    #[inline(always)]
+    fn poll_close(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Result<(), SendError<T>>> {
+        Poll::Ready(Ok(()))
     }
 }
 
-impl<T> Sink for MPMCFutSender<T> {
-    type SinkItem = T;
-    type SinkError = SendError<T>;
+impl<T> Sink<T> for MPMCFutSender<T> {
+    type Error = SendError<T>;
 
     #[inline(always)]
-    fn start_send(&mut self, msg: T) -> StartSend<T, SendError<T>> {
-        (&*self).start_send(msg)
+    fn poll_ready(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), SendError<T>>> {
+        Pin::new(&mut &*self).poll_ready(cx)
     }
 
     #[inline(always)]
-    fn poll_complete(&mut self) -> Poll<(), SendError<T>> {
-        (&*self).poll_complete()
+    fn start_send(self: Pin<&mut Self>, msg: T) -> Result<(), SendError<T>> {
+        Pin::new(&mut &*self).start_send(msg)
+    }
+
+    #[inline(always)]
+    fn poll_flush(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Result<(), SendError<T>>> {
+        Poll::Ready(Ok(()))
+    }
+
+    #[inline(always)]
+    fn poll_close(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Result<(), SendError<T>>> {
+        Poll::Ready(Ok(()))
     }
 }
 
@@ -568,31 +590,28 @@ impl<T> Clone for MPMCFutReceiver<T> {
 
 impl<T> Stream for &MPMCFutReceiver<T> {
     type Item = T;
-    type Error = ();
 
     #[inline(always)]
-    fn poll(&mut self) -> Poll<Option<T>, ()> {
-        (&self.receiver).poll()
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<T>> {
+        Pin::new(&mut &self.receiver).poll_next(cx)
     }
 }
 
 impl<T> Stream for MPMCFutReceiver<T> {
     type Item = T;
-    type Error = ();
 
     #[inline(always)]
-    fn poll(&mut self) -> Poll<Option<T>, ()> {
-        (&*self).poll()
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<T>> {
+        Pin::new(&mut &*self).poll_next(cx)
     }
 }
 
-impl<R, F: FnMut(&T) -> R, T> Stream for MPMCFutUniReceiver<R, F, T> {
+impl<R, F: FnMut(&T) -> R + Unpin, T> Stream for MPMCFutUniReceiver<R, F, T> {
     type Item = R;
-    type Error = ();
 
     #[inline(always)]
-    fn poll(&mut self) -> Poll<Option<R>, ()> {
-        self.receiver.poll()
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<R>> {
+        Pin::new(&mut self.get_mut().receiver).poll_next(cx)
     }
 }
 


### PR DESCRIPTION
Migrating from futures 0.1 to 0.3 could be done almost mechanically, but requires some works since the definition of `Sink` is incompatible.

fixes #6. 

Disclaimer: Although a lot of works are still needed for merging, but I open a draft PR to avoid duplication with the author or other contributors.