### PR TITLE
dependency updates and bin folder reorganisation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,12 +12,14 @@ categories = ['asynchronous', 'concurrency', 'data-structures', 'algorithms']
 edition = "2018"
 
 [dependencies]
-crossbeam = "0.8.0"
-futures = "0.1.30"
-smallvec = "1.5.1"
+crossbeam = "0.8.1"
+futures = "0.1.31"
+smallvec = "1.6.1"
 parking_lot = "0.11.1"
-time = "0.2.23"
 atomic_utilities = "0.5.0"
+
+[dev-dependencies]
+time = "0.3"
 
 # tokio = "0.1.20"
 # tokio-timer = "0.2.11"

--- a/examples/example.rs
+++ b/examples/example.rs
@@ -1,7 +1,6 @@
-extern crate crossbeam;
-extern crate multiqueue2 as multiqueue;
+use multiqueue2 as multiqueue;
 
-use self::crossbeam::scope;
+use crossbeam::scope;
 use self::multiqueue::broadcast_queue;
 
 fn spsc_example() {

--- a/examples/throughput.rs
+++ b/examples/throughput.rs
@@ -1,19 +1,15 @@
-extern crate crossbeam;
-extern crate multiqueue2 as multiqueue;
-extern crate time;
-
-use crate::multiqueue::{broadcast_queue_with, wait, BroadcastReceiver, BroadcastSender};
-use time::OffsetDateTime;
-
+use multiqueue2 as multiqueue;
 
 use crossbeam::scope;
+use time::OffsetDateTime;
 
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Barrier;
 
+use crate::multiqueue::{broadcast_queue_with, wait, BroadcastReceiver, BroadcastSender};
 
 fn precise_time_ns() -> u32{
-    OffsetDateTime::now_utc().nanosecond() - OffsetDateTime::unix_epoch().nanosecond()
+    OffsetDateTime::now_utc().nanosecond() - OffsetDateTime::UNIX_EPOCH.nanosecond()
 }
 
 #[inline(never)]


### PR DESCRIPTION
* updated dependencies with minor changes
* changed `time` to be a `dev-dependency` as it's only used in the `throughput` example
* changed `src/bin` folder into top-level `examples`, which better matches these binaries' intended usage

Note: the `time` version used previously (`0.2.23`) has an unmaintained dependency (*stdweb*), which raises a warning on `cargo-audit`, which was the main reason I wanted it to get updated